### PR TITLE
Junit gitlab improvements

### DIFF
--- a/src/formatters/junit.ts
+++ b/src/formatters/junit.ts
@@ -1,31 +1,58 @@
 import {Issue} from "../issue";
 import {IFormatter} from "./_iformatter";
-
-function escape(xml: string): string {
-  return xml.replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&apos;");
-}
+import {js2xml} from 'xml-js';
 
 export class Junit implements IFormatter {
 
   public output(issues: Issue[], _fileCount: number): string {
-    let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-      "<testsuites>\n" +
-      "  <testsuite name=\"abaplint\" tests=\"" + issues.length + "\" failures=\"" + issues.length + "\" errors=\"0\" skipped=\"0\">\n";
+    let outputObj = {
+      _declaration: {
+        _attributes: {
+          version: '1.0',
+          encoding: 'UTF-8'
+        }
+      },
+      testsuites: {
+        testsuite: {
+          _attributes: {
+            name: 'abaplint',
+            tests: issues.length || 1,
+            failures: issues.length,
+            errors: 0,
+            skipped: 0
+          },
+          testcase: [] as {}[]
+        }
+      }
+    };
 
-    for (const issue of issues) {
-      xml = xml + "    <testcase classname=\"" + issue.getFile().getFilename() +
-        "[" + issue.getStart().getRow() + ", " + issue.getStart().getCol() +
-        "]\" name=\"" + issue.getKey() + "\">\n" +
-        "      <failure message=\"" + escape(issue.getMessage()) + "\"/>\n" +
-        "    </testcase>\n";
+    if(issues.length > 0) {
+      for (const issue of issues) {
+        outputObj.testsuites.testsuite.testcase.push({
+          _attributes: {
+            classname: issue.getFile().getObjectName(),
+            file: issue.getFile().getFilename(),
+            name: `${issue.getFile().getFilename()}: [${issue.getStart().getRow()}, ${issue.getStart().getCol()}] - ${issue.getKey()}`
+          },
+          failure: {
+            _attributes: {
+              message: issue.getKey(),
+            },
+            _cdata: `${issue.getMessage()}`
+          }
+        });
+      }
+    }
+    else {
+      outputObj.testsuites.testsuite.testcase.push({
+        _attributes: {
+          classname: 'none',
+          name: 'OK'
+        },
+      });
     }
 
-    xml = xml + "  </testsuite>\n" +
-      "</testsuites>";
+    let xml = js2xml(outputObj, { compact: true, spaces: 2 });
 
     return xml;
   }

--- a/src/formatters/junit.ts
+++ b/src/formatters/junit.ts
@@ -1,58 +1,57 @@
 import {Issue} from "../issue";
 import {IFormatter} from "./_iformatter";
-import {js2xml} from 'xml-js';
+import {js2xml} from "xml-js";
 
 export class Junit implements IFormatter {
 
   public output(issues: Issue[], _fileCount: number): string {
-    let outputObj = {
+    const outputObj = {
       _declaration: {
         _attributes: {
-          version: '1.0',
-          encoding: 'UTF-8'
-        }
+          version: "1.0",
+          encoding: "UTF-8",
+        },
       },
       testsuites: {
         testsuite: {
           _attributes: {
-            name: 'abaplint',
+            name: "abaplint",
             tests: issues.length || 1,
             failures: issues.length,
             errors: 0,
-            skipped: 0
+            skipped: 0,
           },
-          testcase: [] as {}[]
-        }
-      }
+          testcase: [] as {}[],
+        },
+      },
     };
 
-    if(issues.length > 0) {
+    if (issues.length > 0) {
       for (const issue of issues) {
         outputObj.testsuites.testsuite.testcase.push({
           _attributes: {
             classname: issue.getFile().getObjectName(),
             file: issue.getFile().getFilename(),
-            name: `${issue.getFile().getFilename()}: [${issue.getStart().getRow()}, ${issue.getStart().getCol()}] - ${issue.getKey()}`
+            name: `${issue.getFile().getFilename()}: [${issue.getStart().getRow()}, ${issue.getStart().getCol()}] - ${issue.getKey()}`,
           },
           failure: {
             _attributes: {
               message: issue.getKey(),
             },
-            _cdata: `${issue.getMessage()}`
-          }
+            _cdata: `${issue.getMessage()}`,
+          },
         });
       }
-    }
-    else {
+    } else {
       outputObj.testsuites.testsuite.testcase.push({
         _attributes: {
-          classname: 'none',
-          name: 'OK'
+          classname: "none",
+          name: "OK",
         },
       });
     }
 
-    let xml = js2xml(outputObj, { compact: true, spaces: 2 });
+    const xml = js2xml(outputObj, {compact: true, spaces: 2});
 
     return xml;
   }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -120,7 +120,7 @@ export class Registry {
       try {
         this.findOrCreate(f.getObjectName(), f.getObjectType()).addFile(f);
       } catch (error) {
-        this.issues.push(new Issue({file: f, message: error && error.toString() || "", key: "registry_add"}));
+        this.issues.push(new Issue({file: f, message: error ? error.toString() : "", key: "registry_add"}));
       }
     }
     return this;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -120,7 +120,7 @@ export class Registry {
       try {
         this.findOrCreate(f.getObjectName(), f.getObjectType()).addFile(f);
       } catch (error) {
-        this.issues.push(new Issue({file: f, message: error && error.toString() || '', key: "registry_add"}));
+        this.issues.push(new Issue({file: f, message: error && error.toString() || "", key: "registry_add"}));
       }
     }
     return this;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -120,7 +120,7 @@ export class Registry {
       try {
         this.findOrCreate(f.getObjectName(), f.getObjectType()).addFile(f);
       } catch (error) {
-        this.issues.push(new Issue({file: f, message: error, key: "registry_add"}));
+        this.issues.push(new Issue({file: f, message: error && error.toString() || '', key: "registry_add"}));
       }
     }
     return this;


### PR DESCRIPTION
also changed the xml build from string concatination to use xml-js (already included as dependency) js-object to xml output.

Example output merge request:

https://gitlab.com/sbu-absw/abaplint-example/merge_requests/3

![image](https://user-images.githubusercontent.com/139566/51431265-c1f67400-1c26-11e9-984a-cd572a4ea075.png)
