### PR TITLE
class implementation indent fix

### DIFF
--- a/src/abap/pretty_printer.ts
+++ b/src/abap/pretty_printer.ts
@@ -32,16 +32,24 @@ class Stack {
 }
 
 class Indentation {
+  private file: ABAPFile;
+  private options: IndentationOptions;
+  private globalClasses = new Set();
+
+  constructor(file: ABAPFile, options: IndentationOptions) {
+    this.file = file;
+    this.options = options;
+  }
+
   // returns list of expected indentation for each line/statement?
-  public static run(file: ABAPFile, options: IndentationOptions): number[] {
+  public run(): number[] {
     const ret: number[] = [];
     const init: number = 1;
     let indent: number = init;
     let parentIsEvent: boolean = false;
     const stack = new Stack();
-    const globalClasses = new Set();
 
-    for (const statement of file.getStatements()) {
+    for (const statement of this.file.getStatements()) {
       const type = statement.get();
 
       if (type instanceof Statements.EndIf
@@ -82,7 +90,7 @@ class Indentation {
           || type instanceof Statements.When) {
         indent = stack.peek();
       } else if (type instanceof Statements.EndTry) {
-        indent = stack.pop() - (options.alignTryCatch ? 2 : 4);
+        indent = stack.pop() - (this.options.alignTryCatch ? 2 : 4);
       } else if (type instanceof Statements.EndClass
           || type instanceof Statements.EndCase) {
         indent = stack.pop() - 2;
@@ -124,32 +132,39 @@ class Indentation {
           || type instanceof Statements.Private) {
         indent = indent + 2;
       } else if (type instanceof Statements.Try) {
-        indent = indent + (options.alignTryCatch ? 2 : 4);
+        indent = indent + (this.options.alignTryCatch ? 2 : 4);
         stack.push(indent);
       } else if (type instanceof Statements.ClassDefinition
           || type instanceof Statements.Case
           || type instanceof Statements.ClassImplementation) {
-        indent = indent + 2;
-        if (options.globalClassSkipFirst) {
-          if (type instanceof Statements.ClassDefinition && statement.findFirstExpression(Expressions.ClassGlobal)) {
-            const className = statement.findFirstExpression(Expressions.ClassName);
-            if (className) {
-              globalClasses.add(className.getFirstToken().getStr().toUpperCase());
-            }
-            indent -= 2;
-          }
-          if (type instanceof Statements.ClassImplementation) {
-            const className = statement.findFirstExpression(Expressions.ClassName);
-            if (className && globalClasses.has(className.getFirstToken().getStr().toUpperCase())) {
-              indent -= 2;
-            }
-          }
-        }
+        indent = indent + (this.skipIndentForGlobalClass(statement) ? 0 : 2);
         stack.push(indent);
       }
     }
 
     return ret;
+  }
+
+  private skipIndentForGlobalClass(statement: StatementNode): boolean {
+    if (!this.options.globalClassSkipFirst) {
+      return false;
+    }
+
+    const type = statement.get();
+
+    if (type instanceof Statements.ClassDefinition && statement.findFirstExpression(Expressions.ClassGlobal)) {
+      const className = statement.findFirstExpression(Expressions.ClassName);
+      if (className) {
+        this.globalClasses.add(className.getFirstToken().getStr().toUpperCase());
+      }
+      return true;
+    } else if (type instanceof Statements.ClassImplementation) {
+      const className = statement.findFirstExpression(Expressions.ClassName);
+      if (className && this.globalClasses.has(className.getFirstToken().getStr().toUpperCase())) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 
@@ -181,7 +196,7 @@ export class PrettyPrinter {
   }
 
   public getExpectedIndentation(): number[] {
-    return Indentation.run(this.file, this.options);
+    return (new Indentation(this.file, this.options)).run();
   }
 
   private indentCode() {

--- a/src/abap/pretty_printer.ts
+++ b/src/abap/pretty_printer.ts
@@ -32,24 +32,22 @@ class Stack {
 }
 
 class Indentation {
-  private file: ABAPFile;
   private options: IndentationOptions;
   private globalClasses = new Set();
 
-  constructor(file: ABAPFile, options: IndentationOptions) {
-    this.file = file;
+  constructor(options: IndentationOptions) {
     this.options = options;
   }
 
   // returns list of expected indentation for each line/statement?
-  public run(): number[] {
+  public run(file: ABAPFile): number[] {
     const ret: number[] = [];
     const init: number = 1;
     let indent: number = init;
     let parentIsEvent: boolean = false;
     const stack = new Stack();
 
-    for (const statement of this.file.getStatements()) {
+    for (const statement of file.getStatements()) {
       const type = statement.get();
 
       if (type instanceof Statements.EndIf
@@ -196,7 +194,7 @@ export class PrettyPrinter {
   }
 
   public getExpectedIndentation(): number[] {
-    return (new Indentation(this.file, this.options)).run();
+    return (new Indentation(this.options)).run(this.file);
   }
 
   private indentCode() {

--- a/test/abap/pretty_printer.ts
+++ b/test/abap/pretty_printer.ts
@@ -98,6 +98,26 @@ describe("Pretty printer with globalClassSkipFirst", () => {
       expected: [1, 3, 1, 1],
       options: {globalClassSkipFirst: true},
     },
+    {
+      input: [
+        "class zcl_skip definition public.",
+        "public section.",
+        "methods xxx.",
+        "endclass.",
+        "class zcl_skip implementation.",
+        "method xxx.",
+        "write msg.",
+        "endmethod.",
+        "endclass.",
+        "class zcl_NO_skip implementation.",
+        "method yyy.",
+        "write msg.",
+        "endmethod.",
+        "endclass.",
+      ].join("\n"),
+      expected: [1, 1, 3, 1, 1, 1, 3, 1, 1, 1, 3, 5, 3, 1],
+      options: {globalClassSkipFirst: true},
+    },
   ];
 
   tests.forEach((test) => {


### PR DESCRIPTION
to #337 fix class implementation indent

P.S. indentation code became less readable. I'd propose making the run non-static and split into 2 methods (well, the original one and the "fix" for class indentation). Can add a commit if OK.